### PR TITLE
Old regexpattern does not work for ID's that contain a -

### DIFF
--- a/src/Matcher/YouTubeMatcher.php
+++ b/src/Matcher/YouTubeMatcher.php
@@ -24,7 +24,8 @@ class YouTubeMatcher extends AbstractMatcher
      *
      * @var string
      */
-    protected $pattern = '/^(?:(?:https?:\/\/)?(?:www\.)?youtu\.?be(?:\.com)?\/)(?:watch\?v=|v\/)?([a-zA-Z0-9_-]*)/';
+    protected $pattern = '/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/';
+
 
     /**
      * Return the video ID from the video URL.
@@ -36,7 +37,7 @@ class YouTubeMatcher extends AbstractMatcher
     {
         preg_match($this->pattern, $url, $matches);
 
-        return array_get($matches, 1);
+        return array_get($matches, 2);
     }
 
     /**

--- a/src/Matcher/YouTubeMatcher.php
+++ b/src/Matcher/YouTubeMatcher.php
@@ -24,7 +24,7 @@ class YouTubeMatcher extends AbstractMatcher
      *
      * @var string
      */
-    protected $pattern = '/(http:|https:)?\/\/(www\.)?(youtube.com|youtu.be)\/(watch)?(\?v=)?(\S+)?/';
+    protected $pattern = '/^(?:(?:https?:\/\/)?(?:www\.)?youtu\.?be(?:\.com)?\/)(?:watch\?v=|v\/)?([a-zA-Z0-9_-]*)/';
 
     /**
      * Return the video ID from the video URL.

--- a/src/Matcher/YouTubeMatcher.php
+++ b/src/Matcher/YouTubeMatcher.php
@@ -24,7 +24,7 @@ class YouTubeMatcher extends AbstractMatcher
      *
      * @var string
      */
-    protected $pattern = '/^(?:(?:https?:\/\/)?(?:www\.)?youtu\.?be(?:\.com)?\/)(?:watch\?v=|v\/)?([a-zA-Z0-9_]*)/';
+    protected $pattern = '/(http:|https:)?\/\/(www\.)?(youtube.com|youtu.be)\/(watch)?(\?v=)?(\S+)?/';
 
     /**
      * Return the video ID from the video URL.


### PR DESCRIPTION
Example url: https://www.youtube.com/watch?v=-k-gpG4426s